### PR TITLE
Remove jettison dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,11 +30,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jettison</groupId>
-            <artifactId>jettison</artifactId>
-            <version>1.4.1</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.9.0</version>


### PR DESCRIPTION
Dependency not need. Also Jettison 1.4.1 is not compatible with xstream (see [here](https://x-stream.github.io/faq.html#:~:text=Users%20of%20Java%205%20or,1.3%20or%20higher%20is%20supported.)), if it was necessary we would need to use Jettison version 1.2